### PR TITLE
Require `MYSCOPE` to be your npm username.

### DIFF
--- a/src/wasm-pack/package-code.md
+++ b/src/wasm-pack/package-code.md
@@ -7,7 +7,7 @@ command:
 $ wasm-pack init --scope MYSCOPE
 ```
 
-where `MYSCOPE` is your name or something. Normally you could just type `wasm-pack init` but since
+where `MYSCOPE` is your npm username. Normally you could just type `wasm-pack init` but since
 other people are doing this tutorial as well we don't want conflicts with the `wasm-add` package
 name! This command when run does a few things:
 

--- a/src/wasm-pack/run-the-code.md
+++ b/src/wasm-pack/run-the-code.md
@@ -25,7 +25,7 @@ Now we need to create a `package.json` file that looks like this:
 }
 ```
 
-where `MYSCOPE` is whatever you used before. You can expand this to be a more complete file but
+where `MYSCOPE` is your npm username. You can expand this to be a more complete file but
 we're really just trying to verify that this works!
 
 Next up we'll need to create a small webpack configuration so that we can use the


### PR DESCRIPTION
## Problem
In [8.2.4](https://rustwasm.github.io/book/wasm-pack/package-code.html), it currently says

> ...
 In your project directory run the following command:
`$ wasm-pack init --scope MYSCOPE`
where `MYSCOPE` is your name **or something**.
...

To me, `or something` implies that `MYSCOPE` can be anything.

This is what I thought when I was following the tutorial, so I chose `hello-world` as my scope, and got an error message.

It turns out, according to the [npm scope documentation](https://docs.npmjs.com/misc/scope):
> Each npm user/organization has their own scope, and **only you can add packages in your scope**.

## Solution
To solve this, I simply replaced the misleading `your name or something` with `your npm username`.


