### PR TITLE
Update links pointing to the old rust-nursery to the new rustwasm organisation

### DIFF
--- a/src/introduction.md
+++ b/src/introduction.md
@@ -5,4 +5,4 @@ request!][repo]
 
 [Rust]: https://www.rust-lang.org
 [WebAssembly]: http://webassembly.org/
-[repo]: https://github.com/rust-lang-nursery/rust-wasm
+[repo]: https://github.com/rustwasm/book

--- a/src/js-ffi.md
+++ b/src/js-ffi.md
@@ -6,7 +6,7 @@
 
 > **Note**: this is likely to [change in the near future][export-issue]
 
-[export-issue]: https://github.com/rust-lang-nursery/rust-wasm/issues/29
+[export-issue]: https://github.com/rustwasm/team/issues/29
 
 When using wasm within a JS host, importing and exporting functions from the
 Rust side is straightforward: it works exactly like C. In particular:

--- a/src/tools.md
+++ b/src/tools.md
@@ -38,7 +38,7 @@ This page is meant to be a living document, so feel free to send us a pull reque
 [wasmparser]: https://github.com/yurydelendik/wasmparser.rs
 [wasmtext]: https://github.com/yurydelendik/wasmtext
 [wasmstandalone]: https://github.com/sunfishcode/wasmstandalone
-[wasmsizeprofiler]: https://github.com/rust-lang-nursery/rust-wasm/issues/20
+[wasmsizeprofiler]: https://github.com/rustwasm/team/issues/20
 [ewasm]: https://github.com/ewasm
 [wasm-pack]: https://github.com/ashleygwilliams/wasm-pack
 [wasm-core]: https://github.com/losfair/wasm-core


### PR DESCRIPTION
There were a few links left in the book that pointed to the old rust-lang-nursery repos.