### PR TITLE
Updated wasm-pack tutorial paths

### DIFF
--- a/src/wasm-pack/run-the-code.md
+++ b/src/wasm-pack/run-the-code.md
@@ -65,7 +65,7 @@ We're almost set. Now we need to setup our JS file so that we can run some wasm 
 Make a file called `index.js` and put this inside of it:
 
 ```javascript
-const js = import("@MYSCOPE/wasm-add/wasm_add.js");
+const js = import("@MYSCOPE/wasm-add");
 js.then(js => {
   js.alert_add(3,2);
 });


### PR DESCRIPTION
References [154](https://github.com/rustwasm/team/issues/154)
Updates:
- [x] Change the import statement of index.js
- [x] Test that the changes work as part of the tutorial with the new syntax
