### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/----misleading-unclear-docs.md
+++ b/.github/ISSUE_TEMPLATE/----misleading-unclear-docs.md
@@ -1,0 +1,13 @@
+---
+name: "\U0001F4D1❌ Misleading/Unclear Docs"
+about: Point out documentation that needs to be improved!
+
+---
+
+**Where in the docs did you come across this?**
+
+**Describe what about it does not make sense**
+
+**Why does it not make sense?**
+
+**How could we improve it?**

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,24 @@
+---
+name: "\U0001F41E Bug report"
+about: Create a report for broken code in the docs!
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,0 +1,17 @@
+---
+name: "\U0001F4DD Feature request"
+about: Suggest an idea for the book!
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/---other.md
+++ b/.github/ISSUE_TEMPLATE/---other.md
@@ -1,0 +1,7 @@
+---
+name: "\U0001F4AD Other"
+about: For issues that don't fall into the other categories
+
+---
+
+


### PR DESCRIPTION
When coming to a project sometimes people need to file issues! With different types of issues though different kinds of information is warranted to solve it. Sometimes it's not even an issue but a feature request! This commit adds some issue templates to make it easy for people to file what information we the maintainers need to make better docs.

cc/ @rustwasm/book 
I'd like to hear more of your opinions before we merge this. Should we add more types of issue templates? Do these need to be improved?