### PR TITLE
Use stabilized wasm attributes

### DIFF
--- a/src/game-of-life/setup.md
+++ b/src/game-of-life/setup.md
@@ -122,7 +122,7 @@ WebAssembly. It uses `wasm_bindgen` to interface with JavaScript. It imports the
 takes a `name` parameter and alerts a greeting message.
 
 ```rust
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros)]
 
 extern crate wasm_bindgen;
 

--- a/src/js-ffi.md
+++ b/src/js-ffi.md
@@ -4,16 +4,12 @@
 
 #### From the Rust side
 
-> **Note**: this is likely to [change in the near future][export-issue]
-
-[export-issue]: https://github.com/rustwasm/team/issues/29
-
 When using wasm within a JS host, importing and exporting functions from the
 Rust side is straightforward: it works very similarly to C.
 
 WebAssembly modules declare a sequence of imports, each with a *module name*
-and an *import name*. The module name for an `extern { ... }` block can be specified
-using the [`#[wasm_import_module]`][wasm_import_module] attribute, currently
+and an *import name*. The module name for an `extern { ... }` block can be
+specified using [`#[link(wasm_import_module)]`][wasm_import_module], currently
 it defaults to "env".
 
 Exports have only a single name. In addition to any `extern` functions the
@@ -22,10 +18,8 @@ WebAssembly instance's default linear memory is exported as "memory".
 [wasm_import_module]: https://github.com/rust-lang/rust/issues/52090
 
 ```rust
-#![feature(wasm_import_module)]
-
 // import a JS function called `foo` from the module `mod`
-#[wasm_import_module="mod"]
+#[link(wasm_import_module = "mod")]
 extern { fn foo(); }
 
 // export a Rust function called `bar`

--- a/src/wasm-pack/rust-code.md
+++ b/src/wasm-pack/rust-code.md
@@ -26,7 +26,7 @@ We'll use this later to make sure our `add` function works!
 Now we need to add this to the top of the file:
 
 ```rust
-#![feature(use_extern_macros, wasm_import_module, wasm_custom_section)]
+#![feature(use_extern_macros)]
 extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 ```
@@ -85,7 +85,7 @@ value was! We then return what was inside `c`. Neat!
 This is all the Rust code we need to write. Your `lib.rs` file should look like this by now:
 
 ```rust
-#![feature(use_extern_macros, wasm_import_module, wasm_custom_section)]
+#![feature(use_extern_macros)]
 extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
Some `#![feature]`s are no longer required on the latest nightlies

rust-lang/rust#52445
rust-lang/rust#52353