### PR TITLE
Game of life bundle

### DIFF
--- a/src/game-of-life/production.md
+++ b/src/game-of-life/production.md
@@ -17,7 +17,8 @@ wasm files with the correct [MIME type][MIME]—`application/wasm`.
 
 [MIME]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
 
-> **Warning**: MIME type can't be anything else than `application/wasm`. `application/wasm; charset=utf-8` will result in an error
+> **Warning**: MIME type can't be anything else than `application/wasm`. `application/wasm;
+charset=utf-8` will result in an error.
 
 > **Note**: Server configuration varies by operating system, it's recommended 
 you look up a tutorial for your specific operating system and webserver. These

--- a/src/game-of-life/production.md
+++ b/src/game-of-life/production.md
@@ -17,6 +17,8 @@ wasm files with the correct [MIME type][MIME]—`application/wasm`.
 
 [MIME]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
 
+> **Warning**: MIME type can't be anything else than `application/wasm`. `application/wasm; charset=utf-8` will result in an error
+
 > **Note**: Server configuration varies by operating system, it's recommended 
 you look up a tutorial for your specific operating system and webserver. These
 examples assume an environment like Debian/Ubuntu or CentOS/Red Hat/Fedora.


### PR DESCRIPTION
@Alexendoo When I tested on my own with [a static server from npm](https://www.npmjs.com/package/http-server) I got MIME type errors even though Firefox's debugger showed the type to be "wasm". The problem was that the server appends  `; charset=utf-8` to Content-Type and that is not shown in Firefox so I thought I might add a warning here.
