### PR TITLE
specifying acronyms in Background And Concepts

### DIFF
--- a/src/background-and-concepts.md
+++ b/src/background-and-concepts.md
@@ -6,15 +6,15 @@ WebAssembly is a simple machine model and executable format with an [extensive
 specification].
 
 Although it has currently gathered attention in the JavaScript and Web communities in general,
-it makes no assumptions about its host environment. Thus, it makes sense to think that wasm
+WebAssembly (wasm) makes no assumptions about its host environment. Thus, it makes sense to think that wasm
 will become an important "portable executable" format used in a variety of contexts in the near
  future (we will dedicate some time to take a closer look at wasm's portability features further in the book).
 
-As of *today*, however, wasm is mostly related to JavaScript, which comes in many flavors (including both
-browsers and [Node.js]). Due to JS being widespread and easy to access we will focus mostly on using these
+As of *today*, however, wasm is mostly related to JavaScript (JS), which comes in many flavors (including both
+browsers and [Node.js]). Due to JS being widespread and easy to access, we will focus mostly on using these
 platforms to run Rust-generated wasm, but other interpreters are probably going to be released in the near future.
 
-As a programming language, WebAssembly is comprised of two formats: The binary format and the text format.
+As a programming language, WebAssembly is comprised of two formats: the binary format and the text format.
 Both represent a common structure, albeit in different ways. The text format (generally called `wat`) uses
 [S-expressions], which bears some resemblance to languages like Clojure or Racket.
 The binary format `wasm` is a lower level format, being itself the assembly code which is run by the interpreters.
@@ -42,7 +42,7 @@ For reference, here is a factorial function in `wat`:
 
 If you're curious about how a `wasm` file looks like you can use [wat2wasm demo] with the above code.
 
-WebAssembly has a very simple [memory model]. At the moment, a wasm module has access to a single
+WebAssembly has a very simple [memory model]. At the moment, a wasm module only has access to a single
 "linear memory", which is essentially a flat array of a fixed
 numeric type. This [memory can be grown] by a multiple of the page size (64K),
 and cannot be shrunk.


### PR DESCRIPTION
I think this touches on issue #28 a bit. Potentially opening an issue for this page specifically might make sense. I'm happy to do that if you all think that's the right direction.

**Summary**

I replaced "it" with wasm and added some of the acronyms in parentheses after the full word.
The motivation behind this change was to make it more clear for someone who isn't familiar with wasm when they're reading the docs.

* [x] 👯 This PR is not a duplicate
* [x] 📬 This PR addresses an open issue
* [x] ✅ This PR has passed CI