### PR TITLE
Sequence Error: Fixes the correct npm link/install sequence.

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -244,6 +244,24 @@ import * as wasm from "hello-wasm-pack";
 wasm.greet();
 ```
 
+### Install the dependencies
+
+First, ensure that the local development server and its dependencies are
+installed by running `npm install` within the `wasm-game-of-life/www`
+subdirectory:
+
+```text
+npm install
+```
+
+This command only needs to be run once, and will install the `webpack`
+JavaScript bundler and its development server.
+
+> Note that `webpack` is not required for working with Rust and WebAssembly, it
+> is just the bundler and development server we've chosen for convenience
+> here. Parcel and Rollup should also support importing WebAssembly as
+> ECMAScript modules.
+
 ### Using our Local `wasm-game-of-life` Package in `www`
 
 Rather than use the `hello-wasm-pack` package from npm, we want to use our local
@@ -277,22 +295,6 @@ wasm.greet();
 Our Web page is now ready to be served locally!
 
 ## Serving Locally
-
-First, ensure that the local development server and its dependencies are
-installed by running `npm install` within the `wasm-game-of-life/www`
-subdirectory:
-
-```text
-npm install
-```
-
-This command only needs to be run once, and will install the `webpack`
-JavaScript bundler and its development server.
-
-> Note that `webpack` is not required for working with Rust and WebAssembly, it
-> is just the bundler and development server we've chosen for convenience
-> here. Parcel and Rollup should also support importing WebAssembly as
-> ECMAScript modules.
 
 Next, open a new terminal for the development server. Running the server in a
 new terminal lets us leave it running in the background, and doesn't block us


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

It prevents the game of life template from npm run errors. If it's run as currently described (npm link and afterwards npm install) then the wasm-game-of-life won't be locally launched properly! 🤔 This PR changes the sequence of the described steps:

1. npm install
2. npm link

* [x] 👯 This PR is not a duplicate
* [x] 📬 This PR addresses an open issue #82 
* [x] ✅ This PR has passed CI

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
[open-issues]: https://github.com/rustwasm/book/issues
