### PR TITLE
Fix typo in wasm-bindgen-futures crate name

### DIFF
--- a/src/reference/crates.md
+++ b/src/reference/crates.md
@@ -14,7 +14,7 @@ category.][wasm-category]
 JavaScript. It allows one to import JavaScript things into Rust and export Rust
 things to JavaScript.
 
-### `wasm-bindgen-features` | [crates.io](https://crates.io/crates/wasm-bindgen-futures) | [repository](https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures)
+### `wasm-bindgen-futures` | [crates.io](https://crates.io/crates/wasm-bindgen-futures) | [repository](https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures)
 
 `wasm-bindgen-futures` is a bridge connecting JavaSript `Promise`s and Rust
 `Future`s. It can convert in both directions and is useful when working with


### PR DESCRIPTION
**Summary**

The header for this recommended crate typoed 'futures' as 'features', momentarily confusing and leading me to check if there was another crate bundling multiple `wasm-bindgen` feature crates like `wasm-bindgen-futures`.

* [x] 👯 This PR is not a duplicate
* [ ] 📬 This PR addresses an open issue **No, but trivial change**
* [ ] ✅ This PR has passed CI

