### PR TITLE
Change 'wasm-pack init' to 'wasm-pack build'

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -318,7 +318,7 @@ and you should be greeted with an alert message:
 
 Anytime you make changes and want them reflected on
 [http://localhost:8080/](http://localhost:8080/), just re-run the `wasm-pack
-init` command within the `wasm-game-of-life` directory.
+build` command within the `wasm-game-of-life` directory.
 
 ## Exercises
 


### PR DESCRIPTION
**Summary**
Changes 'wasm-pack init' to 'wasm-pack build' fixes #102

* [X] 👯 This PR is not a duplicate
* [X] 📬 This PR addresses an open issue
* [X] ✅ This PR has passed CI