### PR TITLE
Make drawGrid/drawCells order the same everywhere

### DIFF
--- a/src/game-of-life/interactivity.md
+++ b/src/game-of-life/interactivity.md
@@ -44,8 +44,8 @@ let animationId = null;
 const renderLoop = () => {
   universe.tick();
 
-  drawCells();
   drawGrid();
+  drawCells();
 
   animationId = requestAnimationFrame(renderLoop);
 };
@@ -159,8 +159,8 @@ canvas.addEventListener("click", event => {
 
   universe.toggle_cell(row, col);
 
-  drawCells();
   drawGrid();
+  drawCells();
 });
 ```
 

--- a/src/game-of-life/time-profiling.md
+++ b/src/game-of-life/time-profiling.md
@@ -85,8 +85,8 @@ const renderLoop = () => {
     fps.render(); //new
 
     universe.tick();
-    drawCells();
     drawGrid();
+    drawCells();
 
     animationId = requestAnimationFrame(renderLoop);
 };


### PR DESCRIPTION
In implementing.md, drawGrid/drawCells is reversed compared to all other cases throughout the tutorial. This results in slightly different rendering when interacting—the lines will be slimmer when drawing the cells after the grid—if you forget to change this order in the render loop later on.

![grid1](https://user-images.githubusercontent.com/43048142/46254429-c6d4c380-c48f-11e8-9d3f-447a29036d79.png) ![grid2](https://user-images.githubusercontent.com/43048142/46254433-c9cfb400-c48f-11e8-8e71-cfff872b83df.png)


* [x] 👯 This PR is not a duplicate
* [ ] 📬 This PR addresses an open issue
* [ ] ✅ This PR has passed CI