### PR TITLE
Replace nightly compiler with Rust 1.30 or newer

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -78,7 +78,7 @@ later in the tutorial. We can ignore it for now.
 
 We use `wasm-pack` to orchestrate the following build steps:
 
-* Ensure that we have a nightly Rust compiler and the `wasm32-unknown-unknown`
+* Ensure that we have Rust 1.30 or newer and the `wasm32-unknown-unknown`
   target installed via `rustup`,
 * Compile our Rust sources into a WebAssembly `.wasm` binary via `cargo`,
 * Use `wasm-bindgen` to generate the JavaScript API for using our Rust-generated


### PR DESCRIPTION
Hey, after reading the book I think it would be clearer to mention Rust 1.30 or newer over the nightly compiler. I think it was somewhat confusing after going through the setup [here](https://rustwasm.github.io/book/game-of-life/setup.html#the-rust-toolchain) and then later see the mention of the nightly compiler. This is pity and maybe doesn't makes sense but I thought I would make this PR and write this, please let me know what you guys think. Thanks!

* [x] 👯 This PR is not a duplicate
* [ ] 📬 This PR addresses an open issue
* [ ] ✅ This PR has passed CI

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
[open-issues]: https://github.com/rustwasm/book/issues
