### PR TITLE
Update instantiation MDN link

### DIFF
--- a/src/reference/js-ffi.md
+++ b/src/reference/js-ffi.md
@@ -36,7 +36,7 @@ Within JS, a wasm binary turns into an ES6 module. It must be *instantiated*
 with linear memory and have a set of JS functions matching the expected
 imports.  The details of instantiation are available on [MDN][instantiation].
 
-[instantiation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate
+[instantiation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
 
 The resulting ES6 module will contain all of the functions exported from Rust, now
 available as JS functions.


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

The original link says: "This method is not the most efficient way of fetching and instantiating wasm modules. If at all possible, you should use the newer WebAssembly.instantiateStreaming() method instead, which fetches, compiles, and instantiates a module all in one step, directly from the raw bytecode, so doesn't require conversion to an ArrayBuffer."

* [X] 👯 This PR is not a duplicate
* [ ] 📬 This PR addresses an open issue
* [ ] ✅ This PR has passed CI

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
[open-issues]: https://github.com/rustwasm/book/issues
