### PR TITLE
Time profiling updates

### DIFF
--- a/src/game-of-life/code-size.md
+++ b/src/game-of-life/code-size.md
@@ -347,7 +347,7 @@ execution speed. You'll want to be sure to measure for runtime comparisons
 between JS and WebAssembly to factor that in to how important code size is.
 
 All this to say basically don't dismay immediately if your `*.wasm` file is
-larget than expected! Code size may end up only being one of many factors in the
+larger than expected! Code size may end up only being one of many factors in the
 end-to-end story.
 
 [hacks]: https://hacks.mozilla.org/2018/01/making-webassembly-even-faster-firefoxs-new-streaming-and-tiering-compiler/

--- a/src/game-of-life/time-profiling.md
+++ b/src/game-of-life/time-profiling.md
@@ -417,12 +417,12 @@ We also have to comment out all the `#[wasm_bindgen]` annotations, and the
 `"cdylib"` bits from `Cargo.toml` or else building native code will fail and
 have link errors.
 
-With all that in place, we can run `cargo bench > before.txt` to compile and run our
-benchmark! The `> before.txt` part will take the output from `cargo bench` and put in a file
+With all that in place, we can run `cargo bench | tee before.txt` to compile and run our
+benchmark! The `| tee before.txt` part will take the output from `cargo bench` and put in a file
 called `before.txt`.
 
 ```
-$ cargo bench > before.txt
+$ cargo bench | tee before.txt
     Finished release [optimized + debuginfo] target(s) in 0.0 secs
      Running target/release/deps/wasm_game_of_life-91574dfbe2b5a124
 
@@ -562,7 +562,7 @@ fn live_neighbor_count(&self, row: u32, column: u32) -> u8 {
 Now let's run the benchmarks again! This time output it to `after.txt`.
 
 ```
-$ cargo bench > after.txt
+$ cargo bench | tee after.txt
    Compiling wasm_game_of_life v0.1.0 (file:///home/fitzgen/wasm_game_of_life)
     Finished release [optimized + debuginfo] target(s) in 0.82 secs
      Running target/release/deps/wasm_game_of_life-91574dfbe2b5a124

--- a/src/game-of-life/time-profiling.md
+++ b/src/game-of-life/time-profiling.md
@@ -386,6 +386,13 @@ cost, surprisingly. Another reminder to always guide our efforts with profiling!
 
 [![Screenshot of a Universe::tick timer results](../images/game-of-life/console-time-in-universe-tick.png)](../images/game-of-life/console-time-in-universe-tick.png)
 
+The next section requires the `nightly` compiler. It's required because of
+the [test feature gate](https://doc.rust-lang.org/unstable-book/library-features/test.html)
+we're going to use for the benchmarks. Another tool we will install is [cargo benchcmp][benchcmp].
+It's a small utility for comparing micro-benchmarks produced by `cargo bench`.
+
+[benchcmp]: https://github.com/BurntSushi/cargo-benchcmp
+
 Let's write a native code `#[bench]` doing the same thing that our WebAssembly
 is doing, but where we can use more mature profiling tools. Here is the new
 `wasm-game-of-life/benches/bench.rs`:
@@ -410,11 +417,12 @@ We also have to comment out all the `#[wasm_bindgen]` annotations, and the
 `"cdylib"` bits from `Cargo.toml` or else building native code will fail and
 have link errors.
 
-With all that in place, we can run `cargo bench` to compile and run our
-benchmark!
+With all that in place, we can run `cargo bench > before.txt` to compile and run our
+benchmark! The `> before.txt` part will take the output from `cargo bench` and put in a file
+called `before.txt`.
 
 ```
-$ cargo bench
+$ cargo bench > before.txt
     Finished release [optimized + debuginfo] target(s) in 0.0 secs
      Running target/release/deps/wasm_game_of_life-91574dfbe2b5a124
 
@@ -551,10 +559,10 @@ fn live_neighbor_count(&self, row: u32, column: u32) -> u8 {
 }
 ```
 
-Now let's run the benchmarks again!
+Now let's run the benchmarks again! This time output it to `after.txt`.
 
 ```
-$ cargo bench
+$ cargo bench > after.txt
    Compiling wasm_game_of_life v0.1.0 (file:///home/fitzgen/wasm_game_of_life)
     Finished release [optimized + debuginfo] target(s) in 0.82 secs
      Running target/release/deps/wasm_game_of_life-91574dfbe2b5a124
@@ -571,10 +579,7 @@ test universe_ticks ... bench:      87,258 ns/iter (+/- 14,632)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out
 ```
 
-That looks a whole lot better! We can see just how much better it is with the
-[`cargo benchcmp`][benchcmp] tool:
-
-[benchcmp]: https://github.com/BurntSushi/cargo-benchcmp
+That looks a whole lot better! We can see just how much better it is with the `benchcmp` tool and the two text files we created before:
 
 ```
 $ cargo benchcmp before.txt after.txt


### PR DESCRIPTION
Hey, I found some parts I thought could be improved a bit.

I want to mention the nightly compiler since from the setup we could've used the beta compiler and wasn't required to use the nightly compiler.

I think one line of explanation of `benchcmp` was a good idea. I also removed the ticks (``) around `benchcmp` since they "broke" the link, it was only displayed that it was a link if you'd hover. See the [current version](https://rustwasm.github.io/book/game-of-life/time-profiling.html) of the book for an example. I included the outputting to files in the `cargo bench` command to make it clear how those files came to be when we will compare them.