### PR TITLE
Call drawGrid() and drawCells() prior to the first invocation of tick().

### DIFF
--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -554,8 +554,17 @@ To start the rendering process, we'll use the same code as above to start the
 first iteration of the rendering loop:
 
 ```js
+drawGrid();
+drawCells();
 requestAnimationFrame(renderLoop);
 ```
+
+Note that we call `drawGrid()` and `drawCells()` here _before_ we call
+`requestAnimationFrame()`. The reason we do this is so that the _initial_ state
+of the universe is drawn before we make modifications. If we instead simply
+called `requestAnimationFrame(renderLoop)`, we'd end up with a situation where
+the first frame that was drawn would actually be _after_ the first call to
+`universe.tick()`, which is the second "tick" of the life of these cells.
 
 ## It Works!
 

--- a/src/game-of-life/interactivity.md
+++ b/src/game-of-life/interactivity.md
@@ -42,10 +42,10 @@ let animationId = null;
 // result of `requestAnimationFrame` is assigned to
 // `animationId`.
 const renderLoop = () => {
-  universe.tick();
-
   drawGrid();
   drawCells();
+
+  universe.tick();
 
   animationId = requestAnimationFrame(renderLoop);
 };


### PR DESCRIPTION
**Summary**

This PR adds a `drawGrid()` and `drawCells()` call just before the
first call to `requestAnimationFrame()` in order to ensure that the initial
state of the universe is drawn prior to executing a `Universe.tick()` call.

Explain the **motivation** for making this change. What existing problem does the pull request solve? 🤔

If this is not done, the initial state of the universe is never drawn,
which can be confusing for those looking to implement the exercises where a
specific starting set of cells is desired.


* [x] 👯 This PR is not a duplicate
* [x] 📬 This PR addresses an open issue (#118)
* [x] ✅ This PR has passed CI