### PR TITLE
add template installation and update usage steps

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -193,12 +193,18 @@ publish our package to npm.
 To take our `wasm-game-of-life` package and use it in a Web page, we use [the
 `create-wasm-app` JavaScript project template][create-wasm-app].
 
+### Global install template
+
+```
+npm install -g create-wasm-app
+```
+
 [create-wasm-app]: https://github.com/rustwasm/create-wasm-app
 
 Run this command within the `wasm-game-of-life` directory:
 
 ```
-npm init wasm-app www
+create-wasm-app www
 ```
 
 Here's what our new `wasm-game-of-life/www` subdirectory contains:


### PR DESCRIPTION
### Summary

Explain the **motivation** for making this change. What existing problem does the pull request solve? 🤔

In section `Putting it into a Web Page`:
-  `create-wasm-app` template installation description is insufficient
-  makes usage of `create-wasm-app` semantically stronger
