### PR TITLE
Update link for rust-install

### DIFF
--- a/src/game-of-life/setup.md
+++ b/src/game-of-life/setup.md
@@ -47,7 +47,7 @@ command:
 npm install npm@latest -g
 ```
 
-[rust-install]: https://www.rust-lang.org/en-US/install.html
+[rust-install]: https://www.rust-lang.org/tools/install
 [npm-install]: https://www.npmjs.com/get-npm
 [wasm-pack]: https://github.com/rustwasm/wasm-pack
 [cargo-generate]: https://github.com/ashleygwilliams/cargo-generate


### PR DESCRIPTION
### Summary

Update the `rust-install` link. The current link is broken. The updated link takes the user to the current install page on the rust website.