### PR TITLE
change intro trpl link to the correct Rust book

### DIFF
--- a/src/introduction.md
+++ b/src/introduction.md
@@ -34,7 +34,7 @@ pull request!**][repo]
 
 [Rust]: https://www.rust-lang.org
 [WebAssembly]: https://webassembly.org/
-[trpl]: https://doc.rust-lang.org/book/2018-edition/index.html
+[trpl]: https://doc.rust-lang.org/book/
 [mdn]: https://developer.mozilla.org/en-US/docs/Learn
 [why-rust-wasm]: ./why-rust-and-webassembly.html
 [background]: ./background-and-concepts.html


### PR DESCRIPTION
### Summary
I changed the Rust Programming Language Book link to `https://doc.rust-lang.org/book/`.

Fixes #142 