### PR TITLE
Added Wasmer-runtime to the crates reference

### DIFF
--- a/src/reference/crates.md
+++ b/src/reference/crates.md
@@ -73,6 +73,10 @@ relocs, for example.
 
 An embeddable WebAssembly interpreter from Parity.
 
+### `wasmer-runtime` | [crates.io](https://crates.io/crates/wasmer-runtime) | [repository](https://github.com/wasmerio/wasmer)
+
+An easy-to-use, embeddable WebAssembly JIT runtime from [Wasmer](https://wasmer.io).
+
 ### `cranelift-wasm` | [crates.io](https://crates.io/crates/cranelift-wasm) | [repository](https://github.com/CraneStation/cranelift)
 
 Compile WebAssembly to the native host's machine code. Part of the Cranelift (né


### PR DESCRIPTION
### Summary

We just created a crate for embedding the [Wasmer](https://github.com/wasmerio/wasmer) runtime in any Rust project.

Here's the crate: https://crates.io/crates/wasmer-runtime
And here is an example repo: https://github.com/wasmerio/wasmer-rust-example ([blogpost](https://medium.com/wasmer/executing-webassembly-in-your-rust-application-d5cd32e8ce46))

Thanks for your great work on Rust & WebAssembly! 👏 