### PR TITLE
Fix typo under Linear Memory

### DIFF
--- a/src/what-is-webassembly.md
+++ b/src/what-is-webassembly.md
@@ -42,7 +42,7 @@ demo] with the above code.
 ## Linear Memory
 
 WebAssembly has a very simple [memory model]. A wasm module has access to a
-single "linear memory", which is essentially a flat array of a bytes. This
+single "linear memory", which is essentially a flat array of bytes. This
 [memory can be grown] by a multiple of the page size (64K). It cannot be shrunk.
 
 ## Is WebAssembly Just for the Web?


### PR DESCRIPTION
### Summary

Fixed the following typo:

>A wasm module has access to a single "linear memory", which is essentially a flat array of a bytes

to

>A wasm module has access to a single "linear memory", which is essentially a flat array of bytes

<!-- if applicable, mark this PR as fixing an open issue -->
Fixes #152 

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
