### PR TITLE
Add alternative to npm link

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -314,6 +314,8 @@ wasm.greet();
 
 Our Web page is now ready to be served locally!
 
+> Alternatively, instead of using `npm link` you can add local package to `package.json` in `www` directory via relative path. Just add `"wasm-game-of-life": "file:../pkg"` into either `dependencies` or `devDependencies` section of `package.json`.
+
 ## Serving Locally
 
 Next, open a new terminal for the development server. Running the server in a


### PR DESCRIPTION
### Add alternative to `npm link`

`npm link` method of adding wasm package described in [hello-world.md](https://github.com/rustwasm/book/blob/master/src/game-of-life/hello-world.md) polluting global `npm` package space and is not necessary for tutorial purposes, so I decided to add alternative method. Package can be added by relative path in `www/package.json`.

Though I made it as a footnote, I think maintainers should consider of making it default method, as it much easier than dealing with `npm link`. If so, I can adjust PR. Let me know what you think.

Thank you :-)