### PR TITLE
hello world: reinstall deps before npm run install

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -319,6 +319,11 @@ import * as wasm from "wasm-game-of-life";
 wasm.greet();
 ```
 
+Since we declared a new dependency, we need to install it:
+```text
+npm install
+```
+
 Our Web page is now ready to be served locally!
 
 ## Serving Locally


### PR DESCRIPTION
Without this pass, the subsequent npm run start would fail with:

```
ERROR in ./index.js
Module not found: Error: Can't resolve 'wasm-game-of-life' in '<basedir>/wasm-game-of-life/www'
 @ ./index.js 1:0-42 3:0-10
 @ ./bootstrap.js
```

✋ A similar PR may already be submitted!
Please search 🔎 among the [open pull requests][open-prs] before creating one.

Updating the Game of Life tutorial's code? Also send a PR to
[`rustwasm/wasm_game_of_life`!](https://github.com/rustwasm/wasm_game_of_life)

Now that you've checked, it's time to create your PR. 📝
Thanks for submitting! 🙏

For more information, see the [contributing guide][contributing]. 👫

### Summary

Explain the **motivation** for making this change. What existing problem does the pull request solve? 🤔

<!-- if applicable, mark this PR as fixing an open issue -->
Fixes #___

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
