### PR TITLE
Changed rawgit site to Github pages URL

### DIFF
--- a/src/what-is-webassembly.md
+++ b/src/what-is-webassembly.md
@@ -60,4 +60,4 @@ flavors (including both on the Web and [Node.js]).
 [value types]: https://webassembly.github.io/spec/core/syntax/types.html#value-types
 [Node.js]: https://nodejs.org
 [S-expressions]: https://en.wikipedia.org/wiki/S-expression
-[wat2wasm demo]: https://cdn.rawgit.com/WebAssembly/wabt/aae5a4b7/demo/wat2wasm/
+[wat2wasm demo]: https://webassembly.github.io/wabt/demo/wat2wasm/


### PR DESCRIPTION
### Summary

Rawgit is shutting down in the future.

https://rawgit.com/

> GitHub repositories that served content through RawGit within the last month will continue to be served until at least October of 2019. URLs for other repositories are no longer being served.

Thankfully the demo is already hosted from the repository it lives in:

(from https://github.com/WebAssembly/wabt)

So `https://cdn.rawgit.com/WebAssembly/wabt/aae5a4b7/demo/wat2wasm/` _should_ become `https://webassembly.github.io/wabt/demo/wat2wasm/`