### PR TITLE
rename `init()` to `init_panic_hook()`

### DIFF
--- a/src/reference/debugging.md
+++ b/src/reference/debugging.md
@@ -75,7 +75,7 @@ code path:
 
 ```rust
 #[wasm_bindgen]
-pub fn init() {
+pub fn init_panic_hook() {
     console_error_panic_hook::set_once();
 }
 ```


### PR DESCRIPTION
if this function is named `init` it will conflict with `init` function in the code generated by `wasm-build --target web`

it would produce code like:
```js
/**
*/
export function init() {
    wasm.init();
}
// ...
function init(module) {
    if (typeof module === 'undefined') {
        module = import.meta.url.replace(/\.js$/, '_bg.wasm');
// ...
```

and parsing will fail with:
```

SyntaxError: unknown: Identifier 'init' has already been declared (136:9)

  134 | }
  135 |
> 136 | function init(module) {
      |          ^
  137 |     if (typeof module === 'undefined') {
  138 |         module = import.meta.url.replace(/\.js$/, '_bg.wasm');
  139 |     }
```
