### PR TITLE
change 'adding a line to dependencies' to 'adding dependencies'

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -297,15 +297,17 @@ Rather than use the `hello-wasm-pack` package from npm, we want to use our local
 `wasm-game-of-life` package instead. This will allow us to incrementally develop
 our Game of Life program.
 
-Open up `wasm-game-of-life/www/package.json` and edit the `"dependencies"` to
-include a `"wasm-game-of-life": "file:../pkg"` entry:
+Open up `wasm-game-of-life/www/package.json` and next to `"devDependiecs"`, add the `"dependencies"` field,
+including a `"wasm-game-of-life": "file:../pkg"` entry:
 
 ```js
 {
   // ...
-  "dependencies": {
-    "wasm-game-of-life": "file:../pkg", // Add this line!
-    // ...
+  "dependencies": {                     // Add this three lines block!
+    "wasm-game-of-life": "file:../pkg"
+  },
+  "devDependencies": {
+    //...
   }
 }
 ```


### PR DESCRIPTION
### Summary

Explain the **motivation** for making this change. What existing problem does the pull request solve? 
Non npm users might get confused when they can't find a `dependencies` field in the package.json file.
I just did an `npm init wasm-app` following the tutorial, and package.json now only has `devDependencies` out of the box.

<!-- if applicable, mark this PR as fixing an open issue -->
Fixes #195 
