### PR TITLE
Add some JS code to the wat2wasm test

### DIFF
--- a/src/what-is-webassembly.md
+++ b/src/what-is-webassembly.md
@@ -37,7 +37,16 @@ For reference, here is a factorial function in `wat`:
 ```
 
 If you're curious about what a `wasm` file looks like you can use the [wat2wasm
-demo] with the above code.
+demo] with the above code in the `WAT` panel. And if you add this javascript code 
+to the `JS` panel it will produce a valid output in the `JS LOG` panel:
+```
+const wasmInstance =
+    new WebAssembly.Instance(wasmModule, {});
+const { fac } = wasmInstance.exports;
+for (let i = 1; i <= 15; i++) {
+  console.log(i + "! = " + fac(i));
+}
+```
 
 ## Linear Memory
 


### PR DESCRIPTION
When reading the tutorial and visiting wat2wasm for the first time, it was confusing that, by merely copying the `wat` code the output didn't change, and I suddenly broke the output when I touched the JS code. 
Providing a full example, even without the promise to explain the details right now:
- makes this initial test on `wat2wasm` less frustrating
- reinforces what is explained next, that wasm currently works in combination with javascript, by providing this first experience to the reader.

✋ A similar PR may already be submitted!
Please search 🔎 among the [open pull requests][open-prs] before creating one.

Updating the Game of Life tutorial's code? Also send a PR to
[`rustwasm/wasm_game_of_life`!](https://github.com/rustwasm/wasm_game_of_life)

Now that you've checked, it's time to create your PR. 📝
Thanks for submitting! 🙏

For more information, see the [contributing guide][contributing]. 👫

### Summary

Explain the **motivation** for making this change. What existing problem does the pull request solve? 🤔

<!-- if applicable, mark this PR as fixing an open issue -->
Fixes #___

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
