### PR TITLE
Include /tests in the /wasm-game-of-life tree

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -39,9 +39,11 @@ wasm-game-of-life/
 ├── LICENSE_APACHE
 ├── LICENSE_MIT
 ├── README.md
-└── src
-    ├── lib.rs
-    └── utils.rs
+├── src
+|   ├── lib.rs
+|   └── utils.rs
+└-- tests
+    └-- web.rs
 ```
 
 Let's take a look at a couple of these files in detail.


### PR DESCRIPTION
When going through the steps of the book on Dec 27th, the directory created by `cargo generate --git https://github.com/rustwasm/wasm-pack-template` includes the folder `tests` and the `web.rs` file inside it.
Either we should update the tree or include a note that the contents may vary depending on the template's version, because, on a tutorial, it is very important that all steps are really clear so that, when something unrelated fails, the learner is not uncomfortable that something like this might be the cause.

✋ A similar PR may already be submitted!
Comment: I searched and didn't find a similar submission. 
