### PR TITLE
Highlight code changes using diff

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -291,16 +291,12 @@ our Game of Life program.
 Open up `wasm-game-of-life/www/package.json` and next to `"devDependencies"`, add the `"dependencies"` field,
 including a `"wasm-game-of-life": "file:../pkg"` entry:
 
-```js
-{
-  // ...
-  "dependencies": {                     // Add this three lines block!
-    "wasm-game-of-life": "file:../pkg"
-  },
+```diff
+  "homepage": "https://github.com/rustwasm/create-wasm-app#readme",
++  "dependencies": {
++    "wasm-game-of-life": "file:../pkg"
++  },
   "devDependencies": {
-    //...
-  }
-}
 ```
 
 Next, modify `wasm-game-of-life/www/index.js` to import `wasm-game-of-life`

--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -323,7 +323,7 @@ from running other commands in the meantime. In the new terminal, run this
 command from within the `wasm-game-of-life/www` directory:
 
 ```
-npm run start
+npm start
 ```
 
 Navigate your Web browser to [http://localhost:8080/](http://localhost:8080/)

--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -293,9 +293,9 @@ including a `"wasm-game-of-life": "file:../pkg"` entry:
 
 ```diff
   "homepage": "https://github.com/rustwasm/create-wasm-app#readme",
-+  "dependencies": {
-+    "wasm-game-of-life": "file:../pkg"
-+  },
++ "dependencies": {
++   "wasm-game-of-life": "file:../pkg"
++ },
   "devDependencies": {
 ```
 


### PR DESCRIPTION
### Summary

Highlighting functional code that can be copied 1:1. Most people are familiar with JSON, but having comments and unsupported strings/snippets in the code block could be a footgun. 

Also `npm start` is good enough, it is a core command similar to `npm install`

This is assuming the static page generator supports code diff from github markdown, e.g. https://gist.github.com/salmedina/ad8bea4f46de97ea132f71b0bca73663#file-markdowndiffexample-md?