### PR TITLE
make clearer where to add web-sys as dependency in Debugging chapter

### DIFF
--- a/src/game-of-life/debugging.md
+++ b/src/game-of-life/debugging.md
@@ -37,6 +37,10 @@ First, add `web-sys` as a dependency and enable its `"console"` feature in
 `wasm-game-of-life/Cargo.toml`:
 
 ```toml
+[dependencies]
+
+# ...
+
 [dependencies.web-sys]
 version = "0.3"
 features = [


### PR DESCRIPTION
✋ A similar PR may already be submitted!
Please search 🔎 among the [open pull requests][open-prs] before creating one.

Updating the Game of Life tutorial's code? Also send a PR to
[`rustwasm/wasm_game_of_life`!](https://github.com/rustwasm/wasm_game_of_life)

Now that you've checked, it's time to create your PR. 📝
Thanks for submitting! 🙏

For more information, see the [contributing guide][contributing]. 👫

### Summary

I made the mistake of adding web-sys twice, and also adding it right in the middle of the dependencies list, just like https://github.com/rustwasm/wasm-bindgen/issues/1039. 

I believe this small change makes it clearer where to add web-sys as a dependency with features.

<!-- if applicable, mark this PR as fixing an open issue -->

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
