### PR TITLE
Fix pause not showing current state of Universe

### DIFF
--- a/src/game-of-life/interactivity.md
+++ b/src/game-of-life/interactivity.md
@@ -76,6 +76,7 @@ const play = () => {
 const pause = () => {
   playPauseButton.textContent = "▶";
   cancelAnimationFrame(animationId);
+  drawCells();  // Draw last frame
   animationId = null;
 };
 


### PR DESCRIPTION
#56 # Summary

Explain the **motivation** for making this change. What existing problem does the pull request solve? 🤔

When the game is paused, the displayed Universe does not match the current state of the Universe. Because of this, the first time when a user clicked a cell (i.e. calls `drawCells()`) the displayed Universe will update to the current state, causing unexpected interactions. Calling `drawCells()` in the pause function fixes this.

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
