### PR TITLE
Remove default body margin to remove scrollbars

### DIFF
--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -334,6 +334,7 @@ inside `wasm-game-of-life/www/index.html`'s `<head>`:
 ```html
 <style>
   body {
+    margin: 0;
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
### Summary

The default css for rending the `<body>` makes the page scroll up and down. This will remove browser's default spacing to allow the `100%` property to not go outside of the browser window bounds.

https://rustwasm.github.io/docs/book/game-of-life/implementing.html#rendering-with-javascript