### PR TITLE
Reader is told to run npm install more than once

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -271,8 +271,7 @@ subdirectory:
 npm install
 ```
 
-This command only needs to be run once, and will install the `webpack`
-JavaScript bundler and its development server.
+This command will install the `webpack` JavaScript bundler and its development server.
 
 > Note that `webpack` is not required for working with Rust and WebAssembly, it
 > is just the bundler and development server we've chosen for convenience


### PR DESCRIPTION
The section on installing dependencies states that it is only necessary to run ```npm install``` once, but then goes on to say that you need to run it again in the following sub-section.

I think it is better just to explain why ```npm install``` is required, here.
