### PR TITLE
Add missing wasm_bindgen for Universe implementation

### DIFF
--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -154,6 +154,7 @@ To access the cell at a given row and column, we translate the row and column
 into an index into the cells vector, as described earlier:
 
 ```rust
+#[wasm_bindgen]
 impl Universe {
     fn get_index(&self, row: u32, column: u32) -> usize {
         (row * self.width + column) as usize
@@ -168,6 +169,7 @@ many of its neighbors are alive. Let's write a `live_neighbor_count` method to
 do just that!
 
 ```rust
+#[wasm_bindgen]
 impl Universe {
     // ...
 

--- a/src/game-of-life/testing.md
+++ b/src/game-of-life/testing.md
@@ -48,6 +48,7 @@ the `cells` of a `Universe`. We'll also write a `set_cells` function so we can
 set `cells` in a specific row and column of a `Universe` to be `Alive.`
 
 ```rust
+#[wasm_bindgen]
 impl Universe {
     /// Get the dead and alive values of the entire universe.
     pub fn get_cells(&self) -> &[Cell] {


### PR DESCRIPTION
### Summary

Following the tutorial, I found that the first implementation of the Universe structure is missing the macro of wasm_bindgen. I know that in the following code is set, but when you are following a tutorial, you only focus on parts that change.