### PR TITLE
Update link to cranelift source code

### DIFF
--- a/src/reference/crates.md
+++ b/src/reference/crates.md
@@ -73,7 +73,7 @@ relocs, for example.
 
 An embeddable WebAssembly interpreter from Parity.
 
-### `cranelift-wasm` | [crates.io](https://crates.io/crates/cranelift-wasm) | [repository](https://github.com/CraneStation/cranelift)
+### `cranelift-wasm` | [crates.io](https://crates.io/crates/cranelift-wasm) | [repository](https://github.com/bytecodealliance/wasmtime/tree/master/cranelift)
 
 Compile WebAssembly to the native host's machine code. Part of the Cranelift (né
 Cretonne) code generator project.


### PR DESCRIPTION
## Summary 

The existing URI redirects to https://github.com/bytecodealliance/cranelift which then has a note saying the code has moved to https://github.com/bytecodealliance/wasmtime/tree/master/cranelift.
This puts this last URI as the link of the repository.