### PR TITLE
Fix: Improved consistency in use of "neighbor" spelling

### DIFF
--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -216,16 +216,16 @@ impl Universe {
                 let live_neighbors = self.live_neighbor_count(row, col);
 
                 let next_cell = match (cell, live_neighbors) {
-                    // Rule 1: Any live cell with fewer than two live neighbours
+                    // Rule 1: Any live cell with fewer than two live neighbors
                     // dies, as if caused by underpopulation.
                     (Cell::Alive, x) if x < 2 => Cell::Dead,
-                    // Rule 2: Any live cell with two or three live neighbours
+                    // Rule 2: Any live cell with two or three live neighbors
                     // lives on to the next generation.
                     (Cell::Alive, 2) | (Cell::Alive, 3) => Cell::Alive,
                     // Rule 3: Any live cell with more than three live
-                    // neighbours dies, as if by overpopulation.
+                    // neighbors dies, as if by overpopulation.
                     (Cell::Alive, x) if x > 3 => Cell::Dead,
-                    // Rule 4: Any dead cell with exactly three live neighbours
+                    // Rule 4: Any dead cell with exactly three live neighbors
                     // becomes a live cell, as if by reproduction.
                     (Cell::Dead, 3) => Cell::Alive,
                     // All other cells remain in the same state.


### PR DESCRIPTION
### Summary

Add to the consistency in how the books reads. On most occasions the _American_ English spelling of _"neighbor"_ is used, however on the odd occasion the _Non-American_ English spelling is used.

Fixes #234 

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
