### PR TITLE
Make a note about `fn render()` problem and point a fix

### DIFF
--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -315,6 +315,14 @@ With that, the Rust half of our Game of Life implementation is complete!
 Recompile it to WebAssembly by running `wasm-pack build` within the
 `wasm-game-of-life` directory.
 
+> Note: if `wasm-pack build` doesn't compile (due to [#886](https://github.com/rustwasm/wasm-pack/issues/886) issue),  
+> append your `Cargo.toml` with following:
+> ```toml
+> [package.metadata.wasm-pack.profile.release]
+> wasm-opt = ["-Os", "--enable-mutable-globals"]
+> ```
+> You can replace `-Os` flag with a [variety](https://rustwasm.github.io/book/reference/code-size.html#use-the-wasm-opt-tool) of optimization levels.
+
 ## Rendering with JavaScript
 
 First, let's add a `<pre>` element to `wasm-game-of-life/www/index.html` to


### PR DESCRIPTION
### Summary
Today, there is a catch with `pub fn render(&self) -> String` method. `String` return type crashes `wasm-pack build` on `wasm-pack 
 0.9.1` version, see:
- https://github.com/rustwasm/wasm-pack/issues/886
- https://github.com/rustwasm/wasm-pack/issues/900  

I've made a note on it, with suggested fix. Hope this will help other readers to resolve it quickly, still mentioning the issue explicitly 