### PR TITLE
Do not re-draw grid on every tick

### DIFF
--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -473,7 +473,6 @@ const ctx = canvas.getContext('2d');
 const renderLoop = () => {
   universe.tick();
 
-  drawGrid();
   drawCells();
 
   requestAnimationFrame(renderLoop);


### PR DESCRIPTION
### Summary

Went through the tutorial and was doing some refactoring and couldn't figure out why we would need to re-draw the grid on every tick. Removing seemed to have no noticeable effect.