### PR TITLE
Typo fix: removing characters which seem to have been accidentally inserted

### DIFF
--- a/src/game-of-life/time-profiling.md
+++ b/src/game-of-life/time-profiling.md
@@ -147,7 +147,7 @@ console:
 
 Additionally, `console.time` and `console.timeEnd` pairs will show up in your
 browser's profiler's "timeline" or "waterfall" view:
-pp
+
 [![Screenshot of console.time logs](../images/game-of-life/console-time-in-profiler.png)](../images/game-of-life/console-time-in-profiler.png)
 
 [RAII]: https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization


### PR DESCRIPTION
### Summary

Two characters seem to have been accidentally inserted in the past. As a consequence, an empty line between a paragraph and an image was filled in and the generated HTML looks a bit ugly. This PR fixes that issue.