### PR TITLE
use cargo to install wasm-pack

### DIFF
--- a/src/game-of-life/setup.md
+++ b/src/game-of-life/setup.md
@@ -19,7 +19,9 @@ require Rust 1.30 or newer.
 `wasm-pack` is your one-stop shop for building, testing, and publishing
 Rust-generated WebAssembly.
 
-[Get `wasm-pack` here!][wasm-pack-install]
+```
+cargo install wasm-pack
+```
 
 ## `cargo-generate`
 


### PR DESCRIPTION
wasm-pack can be installed through cargo. That works out of the box on my Mac M1,
as opposed to the previous instruction to download the binary.

✋ A similar PR may already be submitted!
Please search 🔎 among the [open pull requests][open-prs] before creating one.

Updating the Game of Life tutorial's code? Also send a PR to
[`rustwasm/wasm_game_of_life`!](https://github.com/rustwasm/wasm_game_of_life)

Now that you've checked, it's time to create your PR. 📝
Thanks for submitting! 🙏

For more information, see the [contributing guide][contributing]. 👫

### Summary

Explain the **motivation** for making this change. What existing problem does the pull request solve? 🤔

<!-- if applicable, mark this PR as fixing an open issue -->
Fixes #___

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
