### PR TITLE
Remove reference to wasm32-unknown-unknown target

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -93,8 +93,7 @@ code](debugging.html), but we can ignore this file for now.
 
 We use `wasm-pack` to orchestrate the following build steps:
 
-* Ensure that we have Rust 1.30 or newer and the `wasm32-unknown-unknown`
-  target installed via `rustup`,
+* Ensure that we have Rust 1.30 or newer installed via `rustup`,
 * Compile our Rust sources into a WebAssembly `.wasm` binary via `cargo`,
 * Use `wasm-bindgen` to generate the JavaScript API for using our Rust-generated
   WebAssembly.


### PR DESCRIPTION
The target is now automatically installed by wasm-pack as needed:
https://github.com/rustwasm/wasm-pack/issues/613

See also #160.