### PR TITLE
fix diff inside code block

### DIFF
--- a/src/game-of-life/debugging.md
+++ b/src/game-of-life/debugging.md
@@ -68,35 +68,26 @@ Now, we can start logging messages to the console by inserting calls to `log` in
 Rust code. For example, to log each cell's state, live neighbors count, and next
 state, we could modify `wasm-game-of-life/src/lib.rs` like this:
 
-```diff
-diff --git a/src/lib.rs b/src/lib.rs
-index f757641..a30e107 100755
---- a/src/lib.rs
-+++ b/src/lib.rs
-@@ -123,6 +122,14 @@ impl Universe {
-                 let cell = self.cells[idx];
-                 let live_neighbors = self.live_neighbor_count(row, col);
+```rust
+#[wasm_bindgen]
+impl Universe {
+  // ...
 
-+                log!(
-+                    "cell[{}, {}] is initially {:?} and has {} live neighbors",
-+                    row,
-+                    col,
-+                    cell,
-+                    live_neighbors
-+                );
-+
-                 let next_cell = match (cell, live_neighbors) {
-                     // Rule 1: Any live cell with fewer than two live neighbours
-                     // dies, as if caused by underpopulation.
-@@ -140,6 +147,8 @@ impl Universe {
-                     (otherwise, _) => otherwise,
-                 };
+        let cell = self.cells[idx];
+        let live_neighbors = self.live_neighbor_count(row, col);
 
-+                log!("    it becomes {:?}", next_cell);
-+
-                 next[idx] = next_cell;
-             }
-         }
+        log!(
+          "cell[{}, {}] is initially {:?} and has {} live neighbors",
+          row,
+          col,
+          cell,
+          live_neighbors
+        );
+
+        // ...
+        log!("    it becomes {:?}", next_cell);
+        next[idx] = next_cell;
+      }
 ```
 
 ## Using a Debugger to Pause Between Each Tick


### PR DESCRIPTION
The Game of Life Tutorial Book had a code snippet with an actual git diff text. I just wanted to help and put it as normal, copyable code