### PR TITLE
fillRect draws without path

### DIFF
--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -527,8 +527,6 @@ const drawCells = () => {
   const cellsPtr = universe.cells();
   const cells = new Uint8Array(memory.buffer, cellsPtr, width * height);
 
-  ctx.beginPath();
-
   for (let row = 0; row < height; row++) {
     for (let col = 0; col < width; col++) {
       const idx = getIndex(row, col);
@@ -545,8 +543,6 @@ const drawCells = () => {
       );
     }
   }
-
-  ctx.stroke();
 };
 ```
 


### PR DESCRIPTION
### Summary

`fillRect` draws independently of current path.

Ref: for instance MDN [CanvasRenderingContext2D: fillRect() method](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillRect) states

> This method draws directly to the canvas without modifying the current path …



