### PR TITLE
explicitly mention compile-time options of logging crates for code-size reduction

### DIFF
--- a/src/reference/code-size.md
+++ b/src/reference/code-size.md
@@ -220,6 +220,11 @@ code sizes.
 `format!`, `to_string`, etc... can bring in a lot of code bloat. If possible,
 only do string formatting in debug mode, and in release mode use static strings.
 
+Note that the common `tracing` and `log` crates [support compile-time
+filters](https://docs.rs/tracing/latest/tracing/level_filters/index.html) that
+allow to make logging macros compile to nothing (either depending on the log
+level or completely).
+
 ### Avoid Panicking
 
 This is definitely easier said than done, but tools like `twiggy` and manually


### PR DESCRIPTION
I found it possible to shave more than 1% off my already optimized .wasm size by using the `release_max_level_off` feature on the `tracing` crate.  Hence, I suggest to extend the section that already mentions string formatting as a potential vector for code size reduction to point to these features, since `tracing` and `log` are commonly used (also indirectly in dependencies – `bevy` in my case).