### PR TITLE
Use dyn syntax for trait objects

### DIFF
--- a/src/reference/code-size.md
+++ b/src/reference/code-size.md
@@ -304,9 +304,9 @@ copies add up quickly in terms of code size.
 If you use trait objects instead of type parameters, like this:
 
 ```rust
-fn whatever(t: Box<MyTrait>) { ... }
+fn whatever(t: Box<dyn MyTrait>) { ... }
 // or
-fn whatever(t: &MyTrait) { ... }
+fn whatever(t: &dyn MyTrait) { ... }
 // etc...
 ```
 


### PR DESCRIPTION
This fixes a syntax error when using trait objects. They require using the `dyn` syntax now.