### PR TITLE
Add Korean translation and "translations" section

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -28,3 +28,4 @@
   - [Which Crates Will Work Off-the-Shelf with WebAssembly?](./reference/which-crates-work-with-wasm.md)
   - [How to Add WebAssembly Support to a General-Purpose Crate](./reference/add-wasm-support-to-crate.md)
   - [Deploying Rust and WebAssembly to Production](./reference/deploying-to-production.md)
+  - [Translations of the Book](./reference/translations.md)

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -27,10 +27,16 @@ The [reference sections][reference] may be perused in any order.
 > **💡 Tip:** You can search through this book by clicking on the 🔍 icon at the
 > top of the page, or by pressing the `s` key.
 
+
+## Translations
+
+Some community [translations](./reference/translations.md) are also available.
+
 ## Contributing to this book
 
 This book is open source! Find a typo? Did we overlook something? [**Send us a
 pull request!**][repo]
+
 
 [Rust]: https://www.rust-lang.org
 [WebAssembly]: https://webassembly.org/

--- a/src/reference/translations.md
+++ b/src/reference/translations.md
@@ -1,5 +1,5 @@
 # Translations of the Book
 
-If you're interested in translating the book into your own language, feel free to fork the [main repository](https://github.com/rustwasm/book) and create a Pull Request.
+If you're interested in translating the book into your own language, feel free to fork the [main repository](https://github.com/rustwasm/book) and create a pull request.
 
 - [한국어](https://github.com/polyecho/rust-wasm-book-ko)

--- a/src/reference/translations.md
+++ b/src/reference/translations.md
@@ -1,0 +1,5 @@
+# Translations of the Book
+
+If you're interested in translating the book into your own language, feel free to fork the [main repository](https://github.com/rustwasm/book) and create a Pull Request.
+
+- [한국어](https://github.com/polyecho/rust-wasm-book-ko)

--- a/src/reference/translations.md
+++ b/src/reference/translations.md
@@ -2,4 +2,4 @@
 
 If you're interested in translating the book into your own language, feel free to fork the [main repository](https://github.com/rustwasm/book) and create a pull request.
 
-- [한국어](https://github.com/pixelbracket/rust-wasm-book-ko)
+- [한국어](https://wasm.rust-kr.org)

--- a/src/reference/translations.md
+++ b/src/reference/translations.md
@@ -2,4 +2,4 @@
 
 If you're interested in translating the book into your own language, feel free to fork the [main repository](https://github.com/rustwasm/book) and create a pull request.
 
-- [한국어](https://wasm.rust-kr.org)
+- [한국어](https://github.com/rust-kr/wasm.rust-kr.org)

--- a/src/reference/translations.md
+++ b/src/reference/translations.md
@@ -2,4 +2,4 @@
 
 If you're interested in translating the book into your own language, feel free to fork the [main repository](https://github.com/rustwasm/book) and create a pull request.
 
-- [한국어](https://github.com/polyecho/rust-wasm-book-ko)
+- [한국어](https://github.com/pixelbracket/rust-wasm-book-ko)


### PR DESCRIPTION
### Summary

> I created a new account, so I'm opening another pull request to stay up-to-date. Please refer to #312.

I did the translation because I really appreciated this book and I wanted more people to read this. The pull request includes another reference section for translations. Please check `src/introduction.md` too.

If you want to see the translated version, feel free to check this link.
https://evasquare.github.io/rust-wasm-book-ko/

Hope this helps. :)