### PR TITLE
Fix npm run start ERR_OSSL_EVP_UNSUPPORTED

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -327,7 +327,7 @@ from running other commands in the meantime. In the new terminal, run this
 command from within the `wasm-game-of-life/www` directory:
 
 ```
-npm run start
+NODE_OPTIONS=--openssl-legacy-provider npm run start
 ```
 
 Navigate your Web browser to [http://localhost:8080/](http://localhost:8080/)


### PR DESCRIPTION
On newer NodeJs versions, the environment variable  `NODE_OPTIONS=--openssl-legacy-provider` is required to be able to execute `npm run start`.

```yaml
{
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```
