### PR TITLE
Game of life - Hello Wors section - lib.rs to be similar to current wasm-pack-template

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -65,20 +65,14 @@ mod utils;
 
 use wasm_bindgen::prelude::*;
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 #[wasm_bindgen]
-extern {
+extern "C" {
     fn alert(s: &str);
 }
 
 #[wasm_bindgen]
 pub fn greet() {
-    alert("Hello, wasm-game-of-life!");
+    alert("Hello, {{project-name}}!");
 }
 ```
 


### PR DESCRIPTION
### Summary

The code on the ['hello-world' section](https://rustwasm.github.io/docs/book/game-of-life/hello-world.html) does not reflect the state of the user following the tutorial as the [wasm-pack-template](https://github.com/rustwasm/wasm-pack-template/blob/master/src/lib.rs) possibly leading to some confusing.

This PR harmonizes the documentation with the current state of the template. 

Side effect is that code is this pr works with newer versions of rust/webpack 

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
