### PR TITLE
rename `author` field to `authors` in book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,3 +1,3 @@
 [book]
 title = "Rust and WebAssembly"
-author = "The Rust and WebAssembly Working Group"
+authors = ["The Rust and WebAssembly Working Group"]


### PR DESCRIPTION
See the [mdbook documentation](https://rust-lang.github.io/mdBook/format/configuration/general.html)
Apparently the `author` was field was [incorrect documentation](https://github.com/rust-lang/mdBook/issues/2623)