### PR TITLE
Added #[wasm_bindgen] for all mentions of impl Universe

### DIFF
--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -154,6 +154,7 @@ To access the cell at a given row and column, we translate the row and column
 into an index into the cells vector, as described earlier:
 
 ```rust
+#[wasm_bindgen]
 impl Universe {
     fn get_index(&self, row: u32, column: u32) -> usize {
         (row * self.width + column) as usize
@@ -168,6 +169,7 @@ many of its neighbors are alive. Let's write a `live_neighbor_count` method to
 do just that!
 
 ```rust
+#[wasm_bindgen]
 impl Universe {
     // ...
 


### PR DESCRIPTION
### Summary

Explain the **motivation** for making this change. What existing problem does the pull request solve? 🤔

The first mentions of `impl Universe` don't have `#[wasm_bindgen]`, this results in `cargo build` running successfully but the `wasm_game_of_life.d.ts` file containing only this type def for `Universe`:

```ts
export class Universe {
  private constructor();
  free(): void;
}
```

`#[wasm_bindgen]` is added later, which works perfectly! But admittedly, while studying the code, I didn't read the code outside of `impl Universe`, and had to spend time debugging and wondering why the `d.ts` file is correct for `greet()` but not `Universe`.

Might save the time for some other people as well; making sure the `#[wasm_bindgen]` is not missable!